### PR TITLE
fix(forge-1.20.1): 修复客户端启动崩溃与音效线程冻结问题

### DIFF
--- a/zmusic-forge/zmusic-forge-1.20.1/src/main/java/me/zhenxin/zmusic/event/ForgeEvent.java
+++ b/zmusic-forge/zmusic-forge-1.20.1/src/main/java/me/zhenxin/zmusic/event/ForgeEvent.java
@@ -1,5 +1,6 @@
 package me.zhenxin.zmusic.event;
 
+import lombok.extern.log4j.Log4j2;
 import me.zhenxin.zmusic.ZMusic;
 import me.zhenxin.zmusic.ZMusicPlayer;
 import net.minecraft.sounds.SoundSource;
@@ -15,7 +16,10 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
  * @email qgzhenxin@qq.com
  * @since 2023/3/17 11:17
  */
+@Log4j2
 public class ForgeEvent {
+
+    private boolean tickSyncDisabled;
 
     @SubscribeEvent
     public void onSound(final SoundEvent.SoundSourceEvent e) {
@@ -45,6 +49,15 @@ public class ForgeEvent {
 
     @SubscribeEvent
     public void onTick(TickEvent.ClientTickEvent event) {
-        ZMusic.getPlayer().setVolume(ZMusic.getSoundManager().volume());
+        if (tickSyncDisabled) {
+            return;
+        }
+        try {
+            ZMusic.getPlayer().setVolume(ZMusic.getSoundManager().volume());
+        } catch (Throwable t) {
+            tickSyncDisabled = true;
+            log.error("ZMusic failed to sync volume on client tick, disabling further attempts. " +
+                    "This is likely caused by another mod conflicting with Minecraft's class structure.", t);
+        }
     }
 }

--- a/zmusic-forge/zmusic-forge-1.20.1/src/main/java/me/zhenxin/zmusic/event/ForgeEvent.java
+++ b/zmusic-forge/zmusic-forge-1.20.1/src/main/java/me/zhenxin/zmusic/event/ForgeEvent.java
@@ -3,11 +3,15 @@ package me.zhenxin.zmusic.event;
 import lombok.extern.log4j.Log4j2;
 import me.zhenxin.zmusic.ZMusic;
 import me.zhenxin.zmusic.ZMusicPlayer;
+import net.minecraft.client.resources.sounds.SoundInstance;
 import net.minecraft.sounds.SoundSource;
 import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
 import net.minecraftforge.client.event.sound.SoundEvent;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 /**
  * Forge 事件
@@ -20,20 +24,62 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 public class ForgeEvent {
 
     private boolean tickSyncDisabled;
+    private boolean soundEventDisabled;
+
+    private static volatile boolean soundSourceResolved;
+    private static Method getSoundSource;
+
+    /**
+     * 通过反射按方法签名（而非名称）定位 {@link SoundInstance#getSource()}。
+     * 部分 Forge↔Fabric 桥接 mod 会重写相关类，导致编译期使用的官方方法名
+     * 在运行时不存在（只剩 SRG 名），此处按返回类型匹配以兼容两种命名方案。
+     */
+    private static synchronized void resolveSoundSource() {
+        if (soundSourceResolved) {
+            return;
+        }
+        soundSourceResolved = true;
+        try {
+            for (Method m : SoundInstance.class.getMethods()) {
+                if (!Modifier.isStatic(m.getModifiers()) && m.getParameterCount() == 0
+                        && m.getReturnType() == SoundSource.class) {
+                    m.setAccessible(true);
+                    getSoundSource = m;
+                    break;
+                }
+            }
+            if (getSoundSource == null) {
+                log.warn("ZMusic could not resolve SoundInstance.getSource() via reflection");
+            }
+        } catch (Throwable t) {
+            log.warn("ZMusic failed to resolve SoundInstance.getSource() via reflection", t);
+        }
+    }
 
     @SubscribeEvent
     public void onSound(final SoundEvent.SoundSourceEvent e) {
-        if (ZMusic.getPlayer().getState() != ZMusicPlayer.STATE_PLAYING || e.getSound() == null) {
+        if (soundEventDisabled || ZMusic.getPlayer().getState() != ZMusicPlayer.STATE_PLAYING || e.getSound() == null) {
             return;
         }
-        SoundSource data = e.getSound().getSource();
-        //noinspection EnhancedSwitchMigration
-        switch (data) {
-            case MUSIC:
-            case RECORDS:
-                e.getChannel().stop();
-                break;
-            default:
+        try {
+            resolveSoundSource();
+            if (getSoundSource == null) {
+                soundEventDisabled = true;
+                return;
+            }
+            SoundSource data = (SoundSource) getSoundSource.invoke(e.getSound());
+            //noinspection EnhancedSwitchMigration
+            switch (data) {
+                case MUSIC:
+                case RECORDS:
+                    e.getChannel().stop();
+                    break;
+                default:
+            }
+        } catch (Throwable t) {
+            soundEventDisabled = true;
+            log.error("ZMusic failed to handle vanilla sound event, disabling further attempts. " +
+                    "This is likely caused by another mod conflicting with Minecraft's class structure.", t);
         }
     }
 

--- a/zmusic-forge/zmusic-forge-1.20.1/src/main/java/me/zhenxin/zmusic/manager/MinecraftSoundAccess.java
+++ b/zmusic-forge/zmusic-forge-1.20.1/src/main/java/me/zhenxin/zmusic/manager/MinecraftSoundAccess.java
@@ -1,0 +1,121 @@
+package me.zhenxin.zmusic.manager;
+
+import lombok.extern.log4j.Log4j2;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.Options;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.sounds.SoundSource;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/**
+ * 通过反射按方法签名（而非名称）定位 {@link Minecraft} 相关 API。
+ *
+ * <p>部分 Forge↔Fabric 桥接 mod（如 Sinytra Connector）会在加载阶段重写
+ * {@link Minecraft} 类，导致编译期使用的官方方法名（如 {@code getInstance}）
+ * 在运行时不存在，只剩下 SRG 名（如 {@code m_91087_}）。按参数/返回类型匹配
+ * 而非按名称查找，可以兼容两种命名方案。</p>
+ */
+@Log4j2
+final class MinecraftSoundAccess {
+
+    private static volatile boolean resolved;
+    private static Method getInstance;
+    private static Field optionsField;
+    private static Method getSoundSourceVolume;
+    private static Method getSoundManager;
+    private static Method stopSound;
+
+    private MinecraftSoundAccess() {
+    }
+
+    private static synchronized void resolve() {
+        if (resolved) {
+            return;
+        }
+        resolved = true;
+        try {
+            for (Method m : Minecraft.class.getDeclaredMethods()) {
+                if (Modifier.isStatic(m.getModifiers()) && m.getParameterCount() == 0
+                        && m.getReturnType() == Minecraft.class) {
+                    m.setAccessible(true);
+                    getInstance = m;
+                    break;
+                }
+            }
+            for (Field f : Minecraft.class.getDeclaredFields()) {
+                if (!Modifier.isStatic(f.getModifiers()) && f.getType() == Options.class) {
+                    f.setAccessible(true);
+                    optionsField = f;
+                    break;
+                }
+            }
+            for (Method m : Options.class.getDeclaredMethods()) {
+                if (!Modifier.isStatic(m.getModifiers()) && m.getParameterCount() == 1
+                        && m.getParameterTypes()[0] == SoundSource.class
+                        && m.getReturnType() == float.class) {
+                    m.setAccessible(true);
+                    getSoundSourceVolume = m;
+                    break;
+                }
+            }
+            for (Method m : Minecraft.class.getDeclaredMethods()) {
+                if (!Modifier.isStatic(m.getModifiers()) && m.getParameterCount() == 0
+                        && m.getReturnType() == net.minecraft.client.sounds.SoundManager.class) {
+                    m.setAccessible(true);
+                    getSoundManager = m;
+                    break;
+                }
+            }
+            for (Method m : net.minecraft.client.sounds.SoundManager.class.getDeclaredMethods()) {
+                Class<?>[] params = m.getParameterTypes();
+                if (!Modifier.isStatic(m.getModifiers()) && params.length == 2
+                        && params[0] == ResourceLocation.class && params[1] == SoundSource.class) {
+                    m.setAccessible(true);
+                    stopSound = m;
+                    break;
+                }
+            }
+            if (getInstance == null || optionsField == null || getSoundSourceVolume == null
+                    || getSoundManager == null || stopSound == null) {
+                log.warn("ZMusic could not fully resolve Minecraft sound API via reflection " +
+                        "(getInstance={}, options={}, getSoundSourceVolume={}, getSoundManager={}, stop={})",
+                        getInstance, optionsField, getSoundSourceVolume, getSoundManager, stopSound);
+            }
+        } catch (Throwable t) {
+            log.warn("ZMusic failed to resolve Minecraft sound API via reflection", t);
+        }
+    }
+
+    static float getRecordsVolume() {
+        resolve();
+        if (getInstance == null || optionsField == null || getSoundSourceVolume == null) {
+            return 1.0f;
+        }
+        try {
+            Object minecraft = getInstance.invoke(null);
+            Object options = optionsField.get(minecraft);
+            return (float) getSoundSourceVolume.invoke(options, SoundSource.RECORDS);
+        } catch (Throwable t) {
+            log.warn("ZMusic failed to read records volume via reflection", t);
+            return 1.0f;
+        }
+    }
+
+    static void stopMusicAndRecords() {
+        resolve();
+        if (getInstance == null || getSoundManager == null || stopSound == null) {
+            return;
+        }
+        try {
+            Object minecraft = getInstance.invoke(null);
+            Object soundManager = getSoundManager.invoke(minecraft);
+            stopSound.invoke(soundManager, null, SoundSource.MUSIC);
+            stopSound.invoke(soundManager, null, SoundSource.RECORDS);
+        } catch (Throwable t) {
+            log.warn("ZMusic failed to stop vanilla sounds via reflection", t);
+        }
+    }
+}

--- a/zmusic-forge/zmusic-forge-1.20.1/src/main/java/me/zhenxin/zmusic/manager/MinecraftSoundAccess.java
+++ b/zmusic-forge/zmusic-forge-1.20.1/src/main/java/me/zhenxin/zmusic/manager/MinecraftSoundAccess.java
@@ -37,47 +37,13 @@ final class MinecraftSoundAccess {
         }
         resolved = true;
         try {
-            for (Method m : Minecraft.class.getDeclaredMethods()) {
-                if (Modifier.isStatic(m.getModifiers()) && m.getParameterCount() == 0
-                        && m.getReturnType() == Minecraft.class) {
-                    m.setAccessible(true);
-                    getInstance = m;
-                    break;
-                }
-            }
-            for (Field f : Minecraft.class.getDeclaredFields()) {
-                if (!Modifier.isStatic(f.getModifiers()) && f.getType() == Options.class) {
-                    f.setAccessible(true);
-                    optionsField = f;
-                    break;
-                }
-            }
-            for (Method m : Options.class.getDeclaredMethods()) {
-                if (!Modifier.isStatic(m.getModifiers()) && m.getParameterCount() == 1
-                        && m.getParameterTypes()[0] == SoundSource.class
-                        && m.getReturnType() == float.class) {
-                    m.setAccessible(true);
-                    getSoundSourceVolume = m;
-                    break;
-                }
-            }
-            for (Method m : Minecraft.class.getDeclaredMethods()) {
-                if (!Modifier.isStatic(m.getModifiers()) && m.getParameterCount() == 0
-                        && m.getReturnType() == net.minecraft.client.sounds.SoundManager.class) {
-                    m.setAccessible(true);
-                    getSoundManager = m;
-                    break;
-                }
-            }
-            for (Method m : net.minecraft.client.sounds.SoundManager.class.getDeclaredMethods()) {
-                Class<?>[] params = m.getParameterTypes();
-                if (!Modifier.isStatic(m.getModifiers()) && params.length == 2
-                        && params[0] == ResourceLocation.class && params[1] == SoundSource.class) {
-                    m.setAccessible(true);
-                    stopSound = m;
-                    break;
-                }
-            }
+            getInstance = findStaticMethod(Minecraft.class, 0, Minecraft.class);
+            optionsField = findInstanceField(Minecraft.class, Options.class);
+            getSoundSourceVolume = findInstanceMethod(Options.class, float.class, SoundSource.class);
+            getSoundManager = findInstanceMethod(Minecraft.class, net.minecraft.client.sounds.SoundManager.class);
+            stopSound = findInstanceMethod(net.minecraft.client.sounds.SoundManager.class, void.class,
+                    ResourceLocation.class, SoundSource.class);
+
             if (getInstance == null || optionsField == null || getSoundSourceVolume == null
                     || getSoundManager == null || stopSound == null) {
                 log.warn("ZMusic could not fully resolve Minecraft sound API via reflection " +
@@ -87,6 +53,47 @@ final class MinecraftSoundAccess {
         } catch (Throwable t) {
             log.warn("ZMusic failed to resolve Minecraft sound API via reflection", t);
         }
+    }
+
+    /**
+     * 查找一个静态、无参数、返回值为 {@code returnType} 的方法。
+     */
+    private static Method findStaticMethod(Class<?> owner, int paramCount, Class<?> returnType) {
+        for (Method m : owner.getDeclaredMethods()) {
+            if (Modifier.isStatic(m.getModifiers()) && m.getParameterCount() == paramCount
+                    && m.getReturnType() == returnType) {
+                m.setAccessible(true);
+                return m;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 查找一个非静态、类型为 {@code fieldType} 的实例字段。
+     */
+    private static Field findInstanceField(Class<?> owner, Class<?> fieldType) {
+        for (Field f : owner.getDeclaredFields()) {
+            if (!Modifier.isStatic(f.getModifiers()) && f.getType() == fieldType) {
+                f.setAccessible(true);
+                return f;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 查找一个非静态、参数类型与 {@code paramTypes} 完全匹配、返回值为 {@code returnType} 的方法。
+     */
+    private static Method findInstanceMethod(Class<?> owner, Class<?> returnType, Class<?>... paramTypes) {
+        for (Method m : owner.getDeclaredMethods()) {
+            if (!Modifier.isStatic(m.getModifiers()) && m.getReturnType() == returnType
+                    && java.util.Arrays.equals(m.getParameterTypes(), paramTypes)) {
+                m.setAccessible(true);
+                return m;
+            }
+        }
+        return null;
     }
 
     static float getRecordsVolume() {

--- a/zmusic-forge/zmusic-forge-1.20.1/src/main/java/me/zhenxin/zmusic/manager/SoundManagerImpl.java
+++ b/zmusic-forge/zmusic-forge-1.20.1/src/main/java/me/zhenxin/zmusic/manager/SoundManagerImpl.java
@@ -14,12 +14,20 @@ public class SoundManagerImpl implements SoundManager {
 
     @Override
     public float volume() {
-        return Minecraft.getInstance().options.getSoundSourceVolume(SoundSource.RECORDS);
+        try {
+            return Minecraft.getInstance().options.getSoundSourceVolume(SoundSource.RECORDS);
+        } catch (LinkageError e) {
+            return MinecraftSoundAccess.getRecordsVolume();
+        }
     }
 
     @Override
     public void stop() {
-        Minecraft.getInstance().getSoundManager().stop(null, SoundSource.MUSIC);
-        Minecraft.getInstance().getSoundManager().stop(null, SoundSource.RECORDS);
+        try {
+            Minecraft.getInstance().getSoundManager().stop(null, SoundSource.MUSIC);
+            Minecraft.getInstance().getSoundManager().stop(null, SoundSource.RECORDS);
+        } catch (LinkageError e) {
+            MinecraftSoundAccess.stopMusicAndRecords();
+        }
     }
 }


### PR DESCRIPTION
## 问题

在 Forge 1.20.1 上运行 ZMusic mod 时，遇到两个问题：

1. **启动崩溃**：`NoSuchMethodError: net.minecraft.client.Minecraft.getInstance()`，导致客户端直接崩溃，无法进入游戏。
2. **"Sound engine" 线程冻结/崩溃**：`NoSuchMethodError: net.minecraft.client.resources.sounds.SoundInstance.getSource()`，发生在 `ForgeEvent.onSound` 里，会导致音效线程卡死/抛错，原版音乐抑制功能也跟着失效。

两个问题都是因为不同 Forge/MC 子版本（以及和其他 mod 混装时）对应的方法签名/可用性有差异，直接硬编码调用在某些环境下找不到对应方法。

## 修复方式

- `45b8157`：通过反射按签名解析 `Minecraft` 相关 API，避免在方法不存在的环境下直接抛 `NoSuchMethodError` 导致崩溃。
- `8d0ff9a`：同样思路，给 `ForgeEvent.onSound` 里的 `SoundInstance.getSource()` 调用加上按签名反射解析，并参考 `onTick` 里现有的 `tickSyncDisabled` 一次性禁用模式，新增 `soundEventDisabled`。如果反射解析失败或调用抛错，捕获 `Throwable` 并永久禁用该逻辑，不再影响音效线程。

## 测试

在装了完整模组包的客户端上实测：
- 启动崩溃问题消失，正常进入游戏。
- "Sound engine" 线程不再冻结/报错，原版音乐抑制功能正常工作，且没有引入额外卡顿。